### PR TITLE
Update tests to check ChatPage header

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,15 @@
 import { render, screen } from '@testing-library/react';
-import App from './App';
+import ChatPage from './pages/ChatPage';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+beforeAll(() => {
+  Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: jest.fn(),
+  });
+});
+
+test('displays the AI Chat heading', () => {
+  render(<ChatPage />);
+  const heading = screen.getByRole('heading', { name: /AI Chat/i });
+  expect(heading).toBeInTheDocument();
 });

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,8 +1,15 @@
 import { render, screen } from '@testing-library/react';
-import App from './App';
+import ChatPage from './pages/ChatPage';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-}); 
+beforeAll(() => {
+  Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: jest.fn(),
+  });
+});
+
+test('displays the AI Chat heading', () => {
+  render(<ChatPage />);
+  const heading = screen.getByRole('heading', { name: /AI Chat/i });
+  expect(heading).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- replace placeholder tests with a real assertion verifying the `AI Chat` heading
- mock `scrollIntoView` so ChatPage renders in tests

## Testing
- `CI=true npm test -- --watchAll=false`

