### PR TITLE
Fix env variable name for OpenRouter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-VITE_OPENROUTER_API_KEY=your_openrouter_api_key_here
+OPENROUTER_API_KEY=your_openrouter_api_key_here
 VITE_CHATBOT_SYSTEM_PROMPT=Your system prompt here

--- a/README.md
+++ b/README.md
@@ -21,3 +21,17 @@ Braindump is a modern, AI-powered creative canvas designed for brainstorming, no
 
 ---
 
+## Deployment
+
+1. Copy `.env.example` to `.env` and set your OpenRouter API key:
+
+   ```bash
+   cp .env.example .env
+   # edit .env and add your key
+   OPENROUTER_API_KEY=sk-...
+   ```
+
+2. When deploying to Vercel, add an `OPENROUTER_API_KEY` Environment Variable in
+   the Vercel dashboard so the backend can authenticate with OpenRouter.
+
+


### PR DESCRIPTION
## Summary
- rename `VITE_OPENROUTER_API_KEY` to `OPENROUTER_API_KEY` in `.env.example`
- document how to provide `OPENROUTER_API_KEY` locally and on Vercel

## Testing
- `python -m py_compile backend/main.py api/chat.py`

------
https://chatgpt.com/codex/tasks/task_e_684dbd2d6d948324a9f5adec74cc224b