### PR TITLE
Add API key header handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 VITE_OPENROUTER_API_KEY=your_openrouter_api_key_here
 VITE_CHATBOT_SYSTEM_PROMPT=Your system prompt here
+REACT_APP_API_KEY=your_api_key_here

--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ Braindump is a modern, AI-powered creative canvas designed for brainstorming, no
 
 ---
 
+## API Key Header
+
+The chat endpoint expects an `api-key` header. Store your key in an environment variable called `REACT_APP_API_KEY` and it will be sent automatically with requests from the React app.
+

--- a/frontend/src/pages/ChatPage.js
+++ b/frontend/src/pages/ChatPage.js
@@ -29,6 +29,7 @@ function ChatPage() {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'api-key': process.env.REACT_APP_API_KEY,
         },
         body: JSON.stringify({
           prompt: input.trim(),


### PR DESCRIPTION
## Summary
- send `api-key` header from ChatPage using `REACT_APP_API_KEY`
- document header requirement in README
- add sample `REACT_APP_API_KEY` to `.env.example`

## Testing
- `npm test --silent --maxWorkers=2` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dbd2e0a8c83249c918e1528303fc4