### PR TITLE
Secure chat API with header auth

### DIFF
--- a/api/chat.py
+++ b/api/chat.py
@@ -1,15 +1,24 @@
 import os
 import requests
 import json
+import secrets
 from http.server import BaseHTTPRequestHandler
 from dotenv import load_dotenv
 
 # Load environment variables from .env file
 load_dotenv()
 
+API_KEY = os.environ.get("API_KEY")
+
 class handler(BaseHTTPRequestHandler):
     def do_POST(self):
         try:
+            # Verify API key from headers
+            header_key = self.headers.get('api-key')
+            if not header_key or not API_KEY or not secrets.compare_digest(header_key, API_KEY):
+                self.send_error_response(401, 'Invalid API key')
+                return
+
             # Get content length and read body
             content_length = int(self.headers['Content-Length'])
             post_data = self.rfile.read(content_length)
@@ -86,13 +95,14 @@ class handler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header('Access-Control-Allow-Origin', '*')
         self.send_header('Access-Control-Allow-Methods', 'POST, OPTIONS')
-        self.send_header('Access-Control-Allow-Headers', 'Content-Type')
+        self.send_header('Access-Control-Allow-Headers', 'Content-Type, api-key')
         self.end_headers()
     
     def send_error_response(self, status_code, message):
         self.send_response(status_code)
         self.send_header('Content-Type', 'application/json')
         self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Headers', 'Content-Type, api-key')
         self.end_headers()
         
         error_data = json.dumps({"error": message})


### PR DESCRIPTION
## Summary
- secure Python chat endpoint by validating `api-key` header
- expose `API_KEY` and allow CORS to include it

## Testing
- `npm test --silent`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_684dc0e6cbb483248d689ce7a53be386